### PR TITLE
add actions workflow to deploy main branch to gh-pages

### DIFF
--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -1,0 +1,65 @@
+name: docusaurus
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    if: github.event_name != 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+      - name: test docusaurus build
+        working-directory: docs
+        run: |
+          if [ -e yarn.lock ]; then
+          yarn install --frozen-lockfile
+          elif [ -e package-lock.json ]; then
+          npm ci
+          else
+          npm i
+          fi
+          npm run build
+  deploy:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+      - name: add ssh key for repository
+        env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          echo "${{ secrets.GH_PAGES_DEPLOY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          cat <<EOT >> ~/.ssh/config
+          Host github.com
+          HostName github.com
+          IdentityFile ~/.ssh/id_rsa
+          EOT
+      - name: deploy docusaurus build to gh-pages
+        working-directory: docs
+        env:
+          USE_SSH: true
+          GIT_USER: git
+        run: |
+          git config --global user.email "david.collard@cancer.org.uk"
+          git config --global user.name "David Collard"
+          if [ -e yarn.lock ]; then
+          yarn install --frozen-lockfile
+          elif [ -e package-lock.json ]; then
+          npm ci
+          else
+          npm i
+          fi
+          npx docusaurus deploy


### PR DESCRIPTION
a two-in-one workflow that does a test build with docusaurus on pull requests, and deploys the site on merges into the main branch

it's authenticated using a ssh public key for a deploy key in this repo, and a private key store in the repo secrets

this is adapted from the example at https://v2.docusaurus.io/docs/deployment#triggering-deployment-with-github-actions